### PR TITLE
fix: use clash-verge UA and fix flag=clash query param separator

### DIFF
--- a/scripts/runtime/update_proxy_config.py
+++ b/scripts/runtime/update_proxy_config.py
@@ -49,17 +49,15 @@ from scripts.lib.v2ray_subscribe import (  # noqa: E402
     write_v2ray_json_from_outbounds,
 )
 
-_CLASH_SUBSCRIBE_UA = (
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
-    "Chrome/146.0.0.0 Safari/537.36"
-)
+_CLASH_SUBSCRIBE_UA = "clash-verge/2.2.3"
 
 
 def download_profile(profile_name: str, url: str, *, debug: bool = False) -> bool:
     '''
     下载profile
     '''
-    full_url = f"{url}&flag=clash"
+    sep = "&" if "?" in url else "?"
+    full_url = f"{url}{sep}flag=clash"
 
     logger.info(f'{profile_name} : "{full_url}"')
 


### PR DESCRIPTION
Some subscription panels return empty content for browser User-Agents; switch to clash-verge/2.2.3 UA so servers recognize the client as Clash. Also fix URL construction: use '?' when no query string exists in the URL, avoiding '&flag=clash' being appended as a path segment instead of a param.